### PR TITLE
handles object overlapping

### DIFF
--- a/graphic_field_scene_class.py
+++ b/graphic_field_scene_class.py
@@ -45,8 +45,8 @@ class FieldGraphicsScene(QGraphicsScene):
 
         return drop_x, drop_y
 
+
     def _visualise_graphic_item_center(self, type, name):
-        x, y = self.width()/2, self.height()/2
 
         if name == "System":
             new_object = SymObject(0, 0, 500, 500, self, name)
@@ -98,14 +98,15 @@ class FieldGraphicsScene(QGraphicsScene):
         else:
             return
 
+    def paintEvent(self, event):
+        q = QPainter(self)
+        config.drawLines(q)
+
+'''
         if event.mimeData().hasFormat("application/x-system"):
             system_added = self.field.add_component(SystemGraphicsPixmapItem())
             self._add_graphic_item(system_added, "system", "system")
         else:
             component_added = self.field.add_component(ComponentGraphicsPixmapItem())
             self._add_graphic_item(component_added, "component", event.mimeData().text())
-
-
-    def paintEvent(self, event):
-        q = QPainter(self)
-        config.drawLines(q)
+'''

--- a/sym_object.py
+++ b/sym_object.py
@@ -15,14 +15,52 @@ class SymObject(QGraphicsItemGroup):
 
     def __init__(self, x, y, width, height, scene, component_name):
         super(SymObject, self).__init__()
-        self.x = x
-        self.y = y
+        self.connected_objects = []
+        self.isMoving = False
+
+        #initializing to (0, 0) so that future positions are relative to (0, 0)
+        rect = QGraphicsRectItem(0, 0, width, height)
+
+        self.x = scene.width()/2 - width
+        self.y = scene.height()/2 - height
         self.width = width
         self.height = height
-        self.connected_objects = []
-        first = QGraphicsRectItem(scene.width()/2 - 100, scene.height()/2 - 50, width, height)
-        second = QGraphicsTextItem(component_name)
-        second.setPos(first.boundingRect().center() - second.boundingRect().center())
 
-        self.addToGroup(first)
-        self.addToGroup(second)
+        text = QGraphicsTextItem(component_name)
+        text.setPos(rect.boundingRect().center() - text.boundingRect().center())
+        self.addToGroup(rect)
+        self.addToGroup(text)
+
+        self.setPos(scene.width()/2 - width, scene.height()/2 - height)
+
+        for item in config.sym_objects:
+            if self.doOverlap(self.pos().x(), self.pos().y(), self.pos().x() + self.width, self.pos().y() + self.height, item.x, item.y, item.x + item.width, item.y + item.height):
+                self.setPos(item.x + item.width + 10, item.y + item.height + 10)
+                self.x = self.pos().x()
+                self.y = self.pos().y()
+
+        self.setAcceptDrops(True)
+
+    #register mouse press events
+    def mousePressEvent(self, event):
+        super(SymObject, self).mousePressEvent(event)
+
+
+    # when mouse is release on object, update its position including the case
+    # where it overlaps
+    def mouseReleaseEvent(self, event):
+        super(SymObject, self).mouseReleaseEvent(event)
+        #iterate through all sym objects on the screen and check if the object's
+        # current position overlaps with any of them
+        for item in config.sym_objects:
+            if self != item:
+                if self.doOverlap(self.pos().x(), self.pos().y(), self.pos().x() + self.width, self.pos().y() + self.height, item.x, item.y, item.x + item.width, item.y + item.height):
+                    self.setPos(self.x, self.y)
+
+        # update the object's position parameters
+        self.x = self.pos().x()
+        self.y = self.pos().y()
+
+    def doOverlap(self, l1_x, l1_y, r1_x, r1_y, l2_x, l2_y, r2_x, r2_y):
+        notoverlap = l1_x > r2_x or l2_x > r1_x or l1_y > r2_y or l2_y > r1_y
+        return not notoverlap


### PR DESCRIPTION
Added changes to handle objects overlapping when they are clicked on from the menu and when they are dragged and dropped on each other. Every time a new sym object is created/when it is dragged and dropped, we iterate through all the object on the scene and check whether they are overlapping and update its position accordingly.