### PR TITLE
gui: Add option to run catalog with gem5

### DIFF
--- a/catalog/catalog.py
+++ b/catalog/catalog.py
@@ -6,7 +6,7 @@
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PySide2 import QtCore, QtGui, QtWidgets
 import json
 import os
 
@@ -125,6 +125,22 @@ class Ui_MainWindow(object):
 if __name__ == "__main__":
     import sys
     app = QtWidgets.QApplication(sys.argv)
+    MainWindow = QtWidgets.QMainWindow()
+    ui = Ui_MainWindow()
+    ui.setupUi(MainWindow)
+    MainWindow.show()
+    sys.exit(app.exec_())
+
+if __name__ == "__m5_main__":
+    import sys
+    sys.path.append('configs')
+    import m5.objects
+    from common import ObjectList
+
+    mem_list = ObjectList.mem_list
+    mem_list.print()
+
+    app = QtWidgets.QApplication([])
     MainWindow = QtWidgets.QMainWindow()
     ui = Ui_MainWindow()
     ui.setupUi(MainWindow)


### PR DESCRIPTION
This switches out PyQt for PySide since PyQt is not compatible with
python2. Also, it adds a new section at the end of the file that checks
for `__m5_main__` which is like `__main__` except running inside of m5.
This shows an example of importing gem5 objects and printing.

Signed-off-by: Jason Lowe-Power <jason@lowepower.com>