### PR TITLE
set name for object through dialog box

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,6 +43,9 @@ def getSymObjects():
 
             connected_objects = object.connected_objects.split(",")
             for child in connected_objects:
+                if not child:
+                    break
+
                 res += object.name + "." + child + " = " + sym_objects[child].component_name + "("
                 param = extractValue(sym_objects[child].parameters.items())
                 if param:

--- a/graphic_field_scene_class.py
+++ b/graphic_field_scene_class.py
@@ -42,17 +42,20 @@ class FieldGraphicsScene(QGraphicsScene):
         return drop_x, drop_y
 
 
-    def _visualise_graphic_item_center(self, type, name):
+    def _visualise_graphic_item_center(self, type, component_name, name):
 
-        if name == "System":
-            new_object = SymObject(0, 0, 500, 500, self, name)
+        if not name:
+            name = ''.join(random.choice(string.ascii_lowercase) for i in range(7))
+
+        if component_name == "System":
+            new_object = SymObject(0, 0, 500, 500, self, component_name, name)
         else:
-            new_object = SymObject(0, 0, 100, 50, self, name)
+            new_object = SymObject(0, 0, 100, 50, self, component_name, name)
 
         new_object.setFlag(QGraphicsItem.ItemIsMovable, True)
-        var_name = ''.join(random.choice(string.ascii_lowercase) for i in range(7))
-        config.coord_map[(new_object.x, new_object.y)] = var_name
-        config.sym_objects[var_name] = new_object
+
+        config.coord_map[(new_object.x, new_object.y)] = name
+        config.sym_objects[name] = new_object
         config.current_sym_object = new_object
         self.addItem(new_object)
         return new_object

--- a/gui.py
+++ b/gui.py
@@ -183,8 +183,14 @@ class FieldWindow(QMainWindow):
     def doubleClickEvent(self, item):
         if item.parent() is None:
             return
-        config.current_sym_object = config.scene._visualise_graphic_item_center("component", item.text(0))
+
+        name, ok = QInputDialog.getText(self, "Alert", "New SymObject name:")
+        if not ok:
+            return
+
+        config.current_sym_object = config.scene._visualise_graphic_item_center("component", item.text(0), name)
         config.current_sym_object.parameters = copy.deepcopy(self.catalog[item.parent().text(0)][item.text(0)])
+
 
     def treeWidgetClicked(self, item, name): #if single clicking from the treeWidget, don't want to set the current sym object
         config.current_sym_object = None

--- a/run_simple.py
+++ b/run_simple.py
@@ -34,9 +34,9 @@ from __future__ import absolute_import
 import m5
 # import all of the SimObjects
 from m5.objects import *
+shivam = AtomicSimpleCPU()
+shivam.desai = O3Checker()
 
-# set up the root SimObject and start the simulation
-root = Root(full_system = False)
 
 # instantiate all of the objects we've created above
 m5.instantiate()

--- a/sym_object.py
+++ b/sym_object.py
@@ -13,7 +13,7 @@ import config
 
 class SymObject(QGraphicsItemGroup):
 
-    def __init__(self, x, y, width, height, scene, component_name):
+    def __init__(self, x, y, width, height, scene, component_name, name):
         super(SymObject, self).__init__()
         self.connected_objects = "" #TODO: at export, this string will become a list
         self.parameters = {}
@@ -27,7 +27,7 @@ class SymObject(QGraphicsItemGroup):
         self.width = width
         self.height = height
         self.component_name = component_name
-        self.name = ""
+        self.name = name
         self.to_export = 1
 
         text = QGraphicsTextItem(component_name)


### PR DESCRIPTION
When item is double clicked from TreeWidget, shows a dialog box that lets user set the name for an object. If a blank name is entered, a random strings is set as the name. If the user clicks "cancel" on the dialog box, the object is not added. 